### PR TITLE
Add support for certificate pinning

### DIFF
--- a/WebsocketStompKit.podspec
+++ b/WebsocketStompKit.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.source_files = 'WebsocketStompKit/*.{h,m}'
   s.public_header_files = 'WebsocketStompKit/WebsocketStompKit.h'
   s.requires_arc = true
-  s.dependency     'jetfire', '0.1.2'
+  s.dependency     'jetfire', '~> 0.1.5'
 end

--- a/WebsocketStompKit/WebsocketStompKit.h
+++ b/WebsocketStompKit/WebsocketStompKit.h
@@ -100,12 +100,7 @@ typedef void (^STOMPMessageHandler)(STOMPMessage *message);
 /**
  Array of SecCertificateRef
  */
-@property (nonatomic, strong) NSArray *pinnedCertificates;
-
-/**
- Use `pinnedCertificates` for the connection
- */
-@property (nonatomic, assign) BOOL usePinnedCertificates;
+@property (nonatomic, copy) NSArray *pinnedCertificates;
 
 - (id)initWithURL:(NSURL *)theUrl webSocketHeaders:(NSDictionary *)headers useHeartbeat:(BOOL)heartbeat;
 

--- a/WebsocketStompKit/WebsocketStompKit.h
+++ b/WebsocketStompKit/WebsocketStompKit.h
@@ -97,6 +97,16 @@ typedef void (^STOMPMessageHandler)(STOMPMessage *message);
 @property (nonatomic, readonly) BOOL heartbeatActivated;
 @property (nonatomic, weak) id<STOMPClientDelegate> delegate;
 
+/**
+ Array of SecCertificateRef
+ */
+@property (nonatomic, strong) NSArray *pinnedCertificates;
+
+/**
+ Use `pinnedCertificates` for the connection
+ */
+@property (nonatomic, assign) BOOL usePinnedCertificates;
+
 - (id)initWithURL:(NSURL *)theUrl webSocketHeaders:(NSDictionary *)headers useHeartbeat:(BOOL)heartbeat;
 
 - (void)connectWithLogin:(NSString *)login

--- a/WebsocketStompKit/WebsocketStompKit.m
+++ b/WebsocketStompKit/WebsocketStompKit.m
@@ -344,6 +344,25 @@ CFAbsoluteTime serverActivity;
     return self;
 }
 
+- (void)setUsePinnedCertificates:(BOOL)usePinnedCertificates {
+    if (usePinnedCertificates) {
+        NSMutableArray<JFRSSLCert *> *certs = [NSMutableArray array];
+        for (id certificate in _pinnedCertificates) {
+            NSData *certificateData = CFBridgingRelease(SecCertificateCopyData((SecCertificateRef)certificate));
+            if (certificateData) {
+                JFRSSLCert *cert = [[JFRSSLCert alloc] initWithData:certificateData];
+                if (cert) {
+                    [certs addObject:cert];
+                }
+            }
+        }
+        socket.security = [[JFRSecurity alloc] initWithCerts:certs publicKeys:false];
+    } else {
+        socket.security = nil;
+    }
+    _usePinnedCertificates = usePinnedCertificates;
+}
+
 - (BOOL) heartbeatActivated {
     return heartbeat;
 }

--- a/WebsocketStompKit/WebsocketStompKit.m
+++ b/WebsocketStompKit/WebsocketStompKit.m
@@ -344,10 +344,10 @@ CFAbsoluteTime serverActivity;
     return self;
 }
 
-- (void)setUsePinnedCertificates:(BOOL)usePinnedCertificates {
-    if (usePinnedCertificates) {
+- (void)setPinnedCertificates:(NSArray *)pinnedCertificates {
+    if (pinnedCertificates.count > 0) {
         NSMutableArray<JFRSSLCert *> *certs = [NSMutableArray array];
-        for (id certificate in _pinnedCertificates) {
+        for (id certificate in pinnedCertificates) {
             NSData *certificateData = CFBridgingRelease(SecCertificateCopyData((SecCertificateRef)certificate));
             if (certificateData) {
                 JFRSSLCert *cert = [[JFRSSLCert alloc] initWithData:certificateData];
@@ -360,7 +360,7 @@ CFAbsoluteTime serverActivity;
     } else {
         socket.security = nil;
     }
-    _usePinnedCertificates = usePinnedCertificates;
+    _pinnedCertificates = [pinnedCertificates copy];
 }
 
 - (BOOL) heartbeatActivated {


### PR DESCRIPTION
This bumps the jetfire dependency that includes support for certificate pinning, and exposes that functionality in the STOMP client.